### PR TITLE
Instructions on how to install missing components

### DIFF
--- a/podman-desktop
+++ b/podman-desktop
@@ -58,9 +58,12 @@ if [ ! -x "$(command -v podman-compose)" ]; then
 else
   echo "podman-compose found."
 fi
-if [ "$GOOS" = "darwin" ]; then
-  validate "multipass"
+if [ "$GOOS" = "linux" ]; then
+  echo "podman setup complete for Linux"
+  exit 0
 fi
+
+validate "multipass"
 
 while [ $# -gt 0 ]; do
   key="$1"

--- a/podman-desktop
+++ b/podman-desktop
@@ -18,7 +18,7 @@ die() {
   exit 1
 }
 
-brew() {
+install_cmd() {
   set +e
   if [ -z "$(command -v brew)" ]; then
     echo "# Install homebrew for easier MacOS management"
@@ -34,35 +34,14 @@ validate() {
   if [ ! -x "$(command -v "$cmd")" ]; then
     echo "ERROR: \`$cmd\` command not found. Please install $cmd." >&2
     echo "Instructions are:"
-    if [ "$GOOS" = "linux" ]; then
-      echo "apt-get install $cmd"
-    elif [ "$GOOS" = "darwin" ]; then
-      brew "$cmd"
-    else
-      echo "missing $cmd"
-    fi
+    install_cmd "$cmd"
     exit 1
   else
     echo "$cmd found."
   fi
 }
 
-GOOS=$(uname -s | sed s/Darwin/darwin/ | sed s/Linux/linux/)
-
 validate "podman"
-validate "python3"
-if [ ! -x "$(command -v podman-compose)" ]; then
-  echo "ERROR: \`podman-compose\` command not found. Please install podman-compose." >&2
-  echo "Instructions are: python3 -mpip install podman-compose"
-  exit 1
-else
-  echo "podman-compose found."
-fi
-if [ "$GOOS" = "linux" ]; then
-  echo "podman setup complete for Linux"
-  exit 0
-fi
-
 validate "multipass"
 
 while [ $# -gt 0 ]; do

--- a/podman-desktop
+++ b/podman-desktop
@@ -18,8 +18,47 @@ die() {
   exit 1
 }
 
-command -v multipass >/dev/null 2>&1 || die "missing multipass"
-command -v podman >/dev/null 2>&1 || die "missing podman"
+brew() {
+  set +e
+  if [ -z "$(command -v brew)" ]; then
+    echo "# Install homebrew for easier MacOS management"
+    # shellcheck disable=SC2016
+    echo '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"'
+  fi
+  set -e
+  echo "brew install $1"
+}
+
+validate() {
+  cmd=$1
+  if [ ! -x "$(command -v "$cmd")" ]; then
+    echo "ERROR: \`$cmd\` command not found. Please install $cmd." >&2
+    echo "Instructions are:"
+    if [ "$GOOS" = "linux" ]; then
+      echo "apt-get install $cmd"
+    elif [ "$GOOS" = "darwin" ]; then
+      brew "$cmd"
+    fi
+    exit 1
+  else
+    echo "$cmd found."
+  fi
+}
+
+GOOS=$(uname -s | sed s/Darwin/darwin/ | sed s/Linux/linux/)
+
+validate "podman"
+validate "python3"
+if [ ! -x "$(command -v podman-compose)" ]; then
+  echo "ERROR: \`podman-compose\` command not found. Please install podman-compose." >&2
+  echo "Instructions are: python3 -mpip install podman-compose"
+  exit 1
+else
+  echo "podman-compose found."
+fi
+if [ "$GOOS" = "darwin" ]; then
+  validate "multipass"
+fi
 
 while [ $# -gt 0 ]; do
   key="$1"

--- a/podman-desktop
+++ b/podman-desktop
@@ -38,6 +38,8 @@ validate() {
       echo "apt-get install $cmd"
     elif [ "$GOOS" = "darwin" ]; then
       brew "$cmd"
+    else
+      echo "missing $cmd"
     fi
     exit 1
   else


### PR DESCRIPTION
Instead of telling that they are missing something, it would be nice to tell Ubuntu, Debian and MacOS users how to fix situation.
Current implementation doesn't take into account that Fedora/RHEL uses yum instead of apt-get.
As far as I've understood, we only need multipass in MacOS, so we can skip it on Linux users.