### PR TITLE
${FOOBAR:-value} doesn't evaluate tilde

### DIFF
--- a/podman-desktop
+++ b/podman-desktop
@@ -48,7 +48,7 @@ while [ $# -gt 0 ]; do
 done
 
 INSTANCE_NAME="${INSTANCE_NAME:-podman}"
-IDENTITY="${IDENTITY:-~/.ssh/id_rsa}"
+IDENTITY="${IDENTITY:-$HOME/.ssh/id_rsa}"
 PUBKEYFILE=${IDENTITY}.pub
 VERSION_ID="${VERSION_ID:-20.04}"
 MOUNTS=${MOUNTS:-/Users /Volumes /private /tmp /var/folders} # Docker Desktop Defaults


### PR DESCRIPTION
`IDENTITY="${IDENTITY:-~/.ssh/id_rsa}"` will complain that
> cannot find identity ~/.ssh/id_rsa

even if it exists:
> -rw-------  1 jylitalo  staff  2675 May 31 20:19 /Users/jylitalo/.ssh/id_rsa