### PR TITLE
Add buildkit daemon

### DIFF
--- a/podman-desktop
+++ b/podman-desktop
@@ -107,6 +107,33 @@ packages:
   - podman
   - containerd
   - fuse-overlayfs
+
+write_files:
+- path: /lib/systemd/system/buildkitd.service
+  owner: root:root
+  permissions: \"0755\"
+  content: |
+    [Unit]
+    Description=Buildkitd
+    After=network.target
+
+    [Service]
+    Type=simple
+    ExecStart=/opt/buildkit/bin/buildkitd --addr tcp://0.0.0.0:1234
+    
+    [Install]
+    WantedBy=multi-user.target
+
+
+runcmd:
+  - systemctl daemon-reload
+  - mkdir /opt/buildkit
+  - cd /opt/buildkit
+  - curl -L https://github.com/moby/buildkit/releases/download/v0.9.3/buildkit-v0.9.3.linux-amd64.tar.gz > buildkit.tar.gz
+  - tar -xvf buildkit.tar.gz
+  - systemctl daemon-reload
+  - sudo systemctl enable --now buildkitd.service
+  - sudo systemctl start buildkitd.service
 " | multipass launch \
     --name "${INSTANCE_NAME}" \
     --cloud-init - \

--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,20 @@ By default, podman-desktop will mount the same folders as Docker Desktop.
 If you'd like to change the default mounts, set the `MOUNTS` variable to an array
 
 If you'd like to mount nothing, (for example, due to sshfs_server cpu usage) set `MOUNTS` to an empty string.
+
+
+## Image building with buildkit
+
+Podman builds are considerably slower compared to Docker builds. One way to mitigate this is to use [buildkit](https://github.com/moby/buildkit). Multipass instances provisioned with podman-desktop already contain a ready-to-go buildkit daemon. All you need to do is use the buildkit-cli from your host system:
+
+	buildctl \
+		--addr=tcp://$(shell multipass info podman --format json | jq -r ".info.podman.ipv4[]"):1234 \
+		build \
+		--frontend dockerfile.v0 \
+		--local context=. \
+		--local dockerfile=. \
+		--output type=oci,name="thisgetsignored:imagename" \                                                                                               
+		| podman load
+	
+
+Please note, the resulting image will be `localhost/imagename:latest`, because [Buildkit does not seem write OCI compliant image annotations](https://github.com/containers/podman/issues/12560#issuecomment-990826349-permalink).


### PR DESCRIPTION
### What
This PR adjusts the cloud init file to download, install and run a buildkit daemon within the multipass instance. 

### Why
Building images with Podman is slow. Building images with Buildkit is fast.

### Details

You could also run the [buildkit daemon inside podman within multipass](https://github.com/moby/buildkit#podman). This however has turned out to be slower (factor 2) on my machine during the exporting phase.

I'm also happy to contribute other variants to bring in this functionality, for example, by providing an optional command line parameter.